### PR TITLE
Ensure that discovery of R versions on linux is done invoking the command, rather than Rcmd

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = False
-current_version = 0.13.0
+current_version = 0.13.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize =
 	{major}.{minor}.{patch}-{release}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.1
+
+- PR #56 Ensure that discovery of R versions on linux is done invoking the command, rather than Rcmd
+
 ## 0.13.0
 
 - #52 Added roo environment options to see the available R versions to use when generating an environment

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2022, Stefano Borini'
 author = 'Stefano Borini'
 
 # The full version, including alpha/beta/rc tags
-release = '0.13.0'
+release = '0.13.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "roo"
-version = "0.13.0"
+version = "0.13.1"
 description = "A package manager to handle R environments"
 authors = ["Stefano Borini <stefano.borini@astrazeneca.com>"]
 license = "Apache-2.0"

--- a/src/roo/environment.py
+++ b/src/roo/environment.py
@@ -433,7 +433,7 @@ def find_all_installed_r_homes() -> List[Dict]:
                     "active": True,
                 })
             except (FileNotFoundError, KeyError):
-                pass
+                logger.exception("Failed option")
 
         # also try under opt, one version per subdir, which is how github
         # seem to do it. We really need to make this whole detection
@@ -441,6 +441,7 @@ def find_all_installed_r_homes() -> List[Dict]:
         try:
             base_path = pathlib.Path("/opt/R/")
             for entry in base_path.iterdir():
+                logger.info(f"Trying {entry.name}")
                 if re.match(r"\d+\.\d+\.\d+", str(entry.name)):
                     version = _get_rcmd_version(entry / "bin" / "Rcmd")
                     installed_r.append({
@@ -450,7 +451,7 @@ def find_all_installed_r_homes() -> List[Dict]:
                         "active": True,
                     })
         except (FileNotFoundError, KeyError):
-            pass
+            logger.exception("Failed option")
 
     return installed_r
 


### PR DESCRIPTION
Rcmd is not always present, so we can't extract the information from there. The only remaining option is to invoke the command itself.